### PR TITLE
Re-add entity names to states

### DIFF
--- a/TP-HomeAssistant/Worker.cs
+++ b/TP-HomeAssistant/Worker.cs
@@ -243,7 +243,7 @@ namespace TP_HomeAssistant
                 {
                     _dynamicStates.Add(id, value);
 
-                    _messageProcessor.CreateState(new StateCreate { Id = id, Desc = name, DefaultValue = "", ParentGroup = parentGroup });
+                    _messageProcessor.CreateState(new StateCreate { Id = id, Desc = $"{parentGroup} {name}", DefaultValue = "", ParentGroup = parentGroup });
                     if (!string.IsNullOrWhiteSpace(value))
                         _messageProcessor.UpdateState(new StateUpdate { Id = id, Value = value });
                 }

--- a/TP-HomeAssistant/entry.tp
+++ b/TP-HomeAssistant/entry.tp
@@ -1,6 +1,6 @@
 {
   "sdk": 6,
-  "version": 910,
+  "version": 911,
   "name": "Home Assistant Plugin",
   "id": "HomeAssistant",
   "configuration": {


### PR DESCRIPTION
TouchPortal doesn't consistently show state groupings in all state lists. This can cause confusion as there is no other way currently for the user to identify which state is for which entity. The only way to resolve this issue while we wait for TouchPortal to get updated is to re-add entity names to state names as the plugin did prior to groupings. This fix is temporary and will be removed once TouchPortal shows the groupings in all state lists.